### PR TITLE
Update core-foundation dependency to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-loader"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["MSleepyPanda <m.sleepypanda@gmail.com>"]
 license = "MIT"
 readme = "Readme.md"
@@ -17,8 +17,8 @@ libc = "0.2.15"
 winapi = { version = "0.3", default-features = false, features = ["winuser", "wingdi"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-text = "10.0"
-core-foundation = "0.6"
+core-text = "15"
+core-foundation = "0.7"
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 servo-fontconfig = "0.4.0"


### PR DESCRIPTION
This is needed to update WebRender and Gecko consistently to core-foundation-0.7, see https://bugzilla.mozilla.org/show_bug.cgi?id=1628772

I bumped the crate version (will need a release...) because as far as I see the dependency shows up in public API of the crate.